### PR TITLE
Fix #27 + additional fixes

### DIFF
--- a/loadshedding.py
+++ b/loadshedding.py
@@ -320,6 +320,7 @@ if __name__ == "__main__":
         fh.setLevel(logging.DEBUG)
         fh.setFormatter(
             logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+        fh.namer = switch_last_two_suffixes
         logger_crash.addHandler(fh)
         return logger_crash
 

--- a/loadshedding.py
+++ b/loadshedding.py
@@ -38,6 +38,9 @@ def main(
         stage_current = get_stage_direct(configuration_user['API_URL'])
     elif configuration_user['QUERY_MODE'].lower() == \
             'loadshedding_thingamabob':
+        import zoneinfo
+        date_now = date_now.replace(tzinfo=zoneinfo.ZoneInfo('localtime'))
+
         response = get_stage_schedule(configuration_user['API_URL'])
         logger_stage.info(f'{response}')
 
@@ -46,14 +49,15 @@ def main(
         stage_schedule_csv = json.loads(response)['schedule_csv']
         stage_schedule = \
             loadshedding_thingamabob.schedule.Schedule.from_string(
-                stage_schedule_csv
+                stage_schedule_csv,
+                timezone=response['timezone'] if 'timezone' in response else 'Africa/Johannesburg',
             )
-        logger.info(f'stage_schedule: {stage_schedule}')
+        logger.info(f'stage_schedule:\n{stage_schedule}')
 
         # Get current stage
         date_soon = \
             date_now + timedelta(minutes=configuration_user['PAD_START'])
-        stage_current = stage_schedule.stage(date_soon.timestamp())
+        stage_current = stage_schedule.stage(date_soon)
     logger.info(f'stage_current: {stage_current}')
 
     transforms = {

--- a/loadshedding.py
+++ b/loadshedding.py
@@ -6,7 +6,7 @@ import os
 import urllib.request
 import json
 import pathlib
-
+import zoneinfo
 
 import configuration
 import lutils.lcsv
@@ -32,15 +32,14 @@ def main(
         f'configuration_user={configuration_user} '
     )
 
-    date_now = datetime.now()
+    # Get the current datetime in the 'Africa/Johannesburg' timezone
+    # But remove the timezone info, since the rest of the script is not timezone aware
+    date_now = datetime.now(tz=zoneinfo.ZoneInfo('Africa/Johannesburg')).replace(tzinfo=None)
 
     if configuration_user['QUERY_MODE'].lower() == 'direct':
         stage_current = get_stage_direct(configuration_user['API_URL'])
     elif configuration_user['QUERY_MODE'].lower() == \
             'loadshedding_thingamabob':
-        import zoneinfo
-        date_now = date_now.replace(tzinfo=zoneinfo.ZoneInfo('localtime'))
-
         response = get_stage_schedule(configuration_user['API_URL'])
         logger_stage.info(f'{response}')
 
@@ -56,8 +55,8 @@ def main(
         logger.info(f'stage_schedule:\n{stage_schedule}')
 
         # Get current stage
-        date_soon = \
-            date_now + timedelta(minutes=configuration_user['PAD_START'])
+        date_soon = date_now + timedelta(minutes=configuration_user['PAD_START'])
+        date_soon = date_soon.replace(tzinfo=zoneinfo.ZoneInfo('Africa/Johannesburg'))
         stage_current = stage_schedule.stage(date_soon)
     logger.info(f'stage_current: {stage_current}')
 

--- a/loadshedding.py
+++ b/loadshedding.py
@@ -46,11 +46,12 @@ def main(
 
         # Build schedule
         import loadshedding_thingamabob.schedule
-        stage_schedule_csv = json.loads(response)['schedule_csv']
+        response_d = json.loads(response)
+        stage_schedule_csv = response_d['schedule_csv']
         stage_schedule = \
             loadshedding_thingamabob.schedule.Schedule.from_string(
                 stage_schedule_csv,
-                timezone=response['timezone'] if 'timezone' in response else 'Africa/Johannesburg',
+                timezone=response_d['timezone'] if 'timezone' in response_d else 'Africa/Johannesburg',
             )
         logger.info(f'stage_schedule:\n{stage_schedule}')
 

--- a/loadshedding.py
+++ b/loadshedding.py
@@ -276,32 +276,6 @@ def get_override_status(timeout: int, dialog_msg: str):
 
 
 if __name__ == "__main__":
-    def switch_last_two_suffixes(base_filename: str):
-        """Switch the last two suffixes of the filename
-        Used in TimedRotatingFileHandler as .namer
-            to switch fix the filename upon rotating, e.g.
-            filename = module.log
-            on rotate: base_filename = module.log.datetime
-
-        Output of this function will then be:
-            switch_last_two_suffixes("module.log.datetime") ->
-            module.datetime.log
-
-        Args:
-            base_filename (str): _description_
-
-        Returns:
-            _type_: _description_
-        """
-        base_filename = pathlib.PurePath(base_filename)
-        parent = base_filename.parent
-        name = base_filename.name.split('.')
-        assert len(name) >= 2
-
-        name = '.'.join(name[:-2] + [name[-1], name[-2]])
-
-        return str(parent / name)
-
     def get_logger(name, filename):
         filename = pathlib.Path(filename)
         if not filename.suffix:
@@ -315,12 +289,11 @@ if __name__ == "__main__":
         ch.setLevel(logging.DEBUG)
         logger_crash.addHandler(ch)
         fh = logging.handlers.TimedRotatingFileHandler(
-            filename, when="midnight"
+            filename, when="midnight", backupCount=30,  # Manually set backup count for testing
         )
         fh.setLevel(logging.DEBUG)
         fh.setFormatter(
             logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-        fh.namer = switch_last_two_suffixes
         logger_crash.addHandler(fh)
         return logger_crash
 


### PR DESCRIPTION
Use 'Africa/Johannesburg' as the default timezone when parsing schedules
Timezone of current stage is assumed to be 'Africa/Johannesburg'
System-timezone can be set to anything now. Previously 'Africa/Johannesburg' was assumed which is not necessarily true on poorly configured devices or devices in other timezones (hope that doesn't become relevant).

Additionally, fixed logfile rotation and naming, as well as related bugs w.r.t. the rotation.